### PR TITLE
解决JSONPath的$..xx匹配多个值问题，解决多值选项变量无法传递

### DIFF
--- a/backend/src/main/java/io/metersphere/api/jmeter/JMeterVars.java
+++ b/backend/src/main/java/io/metersphere/api/jmeter/JMeterVars.java
@@ -1,5 +1,6 @@
 package io.metersphere.api.jmeter;
 
+import com.alibaba.fastjson.JSON;
 import io.github.ningyu.jmeter.plugin.dubbo.sample.DubboSample;
 import org.apache.jmeter.extractor.JSR223PostProcessor;
 import org.apache.jmeter.extractor.RegexExtractor;
@@ -30,12 +31,29 @@ public class JMeterVars {
      * @param vars
      * @param extract
      */
-    public static void addVars(Integer testId, JMeterVariables vars, String extract) {
+     public static void addVars(Integer testId, JMeterVariables vars, String extract) {
         JMeterVariables vs = new JMeterVariables();
-
         if (!StringUtils.isEmpty(extract) && vars != null) {
             List<String> extracts = Arrays.asList(extract.split(";"));
             Optional.ofNullable(extracts).orElse(new ArrayList<>()).forEach(item -> {
+
+                String nrKey = item + "_matchNr";
+                Object nr = vars.get(nrKey);
+                if (nr != null) {
+                    int nrv = 0;
+                    try {
+                        nrv = Integer.valueOf(String.valueOf(nr));
+                    } catch (Exception e) {
+                    }
+                    if (nrv > 0) {
+                        List<Object> data = new ArrayList<>();
+                        for (int i = 1; i < nrv + 1; i++) {
+                            data.add(vars.get(item + "_" + i));
+                        }
+                        String array = JSON.toJSONString(data);
+                        vars.put(item, array);
+                    }
+                }
                 vs.put(item, vars.get(item) == null ? "" : vars.get(item));
             });
             vs.remove("TESTSTART.MS"); // 标示变量移除


### PR DESCRIPTION
解决使用JSONPath的$..xx的语法匹配多个值时，提取出来的值不应该只有一个，
解决多值匹配时候变量无法传递问题