### PR TITLE
swaggerParser RefProperty bug fix

### DIFF
--- a/backend/src/main/java/io/metersphere/api/parse/Swagger2Parser.java
+++ b/backend/src/main/java/io/metersphere/api/parse/Swagger2Parser.java
@@ -283,6 +283,12 @@ public class Swagger2Parser extends ApiImportAbstractParser {
                     } else {
                         jsonObject.put(key, new ArrayList<>());
                     }
+                } else if (value instanceof RefProperty) {
+                    RefProperty refProperty = (RefProperty) value;
+                    String simpleRef = refProperty.getSimpleRef();
+                    refSet.add(simpleRef);
+                    Model model = definitions.get(simpleRef);
+                    jsonObject.put(key, getBodyParameters(model.getProperties(), refSet));
                 } else {
                     jsonObject.put(key, getDefaultValueByPropertyType(value));
                 }


### PR DESCRIPTION
当Property类型为RefProperty时候,如果上层不是ArrayProperty, 写入结果错误