### PR TITLE
Bug修复：swagger接口的入参必填与非必填。目前是没有判断swagger的必填与否，全部固定为必填。

### DIFF
--- a/backend/src/main/java/io/metersphere/api/dto/scenario/KeyValue.java
+++ b/backend/src/main/java/io/metersphere/api/dto/scenario/KeyValue.java
@@ -40,6 +40,15 @@ public class KeyValue {
         this.required = true;
     }
 
+    public KeyValue(String name, String value, String description, String contentType, boolean required) {
+        this.name = name;
+        this.value = value;
+        this.description = description;
+        this.contentType = contentType;
+        this.enable = true;
+        this.required = required;
+    }
+
     public boolean isValid() {
         return (StringUtils.isNotBlank(name) || StringUtils.isNotBlank(value)) && !StringUtils.equalsIgnoreCase(type, "file");
     }

--- a/backend/src/main/java/io/metersphere/api/parse/ApiImportAbstractParser.java
+++ b/backend/src/main/java/io/metersphere/api/parse/ApiImportAbstractParser.java
@@ -118,10 +118,10 @@ public abstract class ApiImportAbstractParser implements ApiImportParser {
     }
 
     protected void addCookie(List<KeyValue> headers, String key, String value) {
-        addCookie(headers, key, value, "");
+        addCookie(headers, key, value, "", "", true);
     }
 
-    protected void addCookie(List<KeyValue> headers, String key, String value, String description) {
+    protected void addCookie(List<KeyValue> headers, String key, String value, String description, String contentType, boolean required) {
         boolean hasCookie = false;
         for (KeyValue header : headers) {
             if (StringUtils.equalsIgnoreCase("Cookie", header.getName())) {
@@ -131,15 +131,15 @@ public abstract class ApiImportAbstractParser implements ApiImportParser {
             }
         }
         if (!hasCookie) {
-            addHeader(headers, "Cookie", key + "=" + value + ";", description);
+            addHeader(headers, "Cookie", key + "=" + value + ";", description, "", required);
         }
     }
 
     protected void addHeader(List<KeyValue> headers, String key, String value) {
-        addHeader(headers, key, value, "");
+        addHeader(headers, key, value, "", "", true);
     }
 
-    protected void addHeader(List<KeyValue> headers, String key, String value, String description) {
+    protected void addHeader(List<KeyValue> headers, String key, String value, String description, String contentType, boolean required) {
         boolean hasContentType = false;
         for (KeyValue header : headers) {
             if (StringUtils.equalsIgnoreCase(header.getName(), key)) {
@@ -147,7 +147,7 @@ public abstract class ApiImportAbstractParser implements ApiImportParser {
             }
         }
         if (!hasContentType) {
-            headers.add(new KeyValue(key, value, description));
+            headers.add(new KeyValue(key, value, description, contentType, required));
         }
     }
 //    protected void addHeader(HttpRequest request, String key, String value) {

--- a/backend/src/main/java/io/metersphere/api/parse/Swagger2Parser.java
+++ b/backend/src/main/java/io/metersphere/api/parse/Swagger2Parser.java
@@ -178,12 +178,14 @@ public class Swagger2Parser extends ApiImportAbstractParser {
 
     private void parseCookieParameters(Parameter parameter, List<KeyValue> headers) {
         CookieParameter cookieParameter = (CookieParameter) parameter;
-        addCookie(headers, cookieParameter.getName(), "", getDefaultStringValue(cookieParameter.getDescription()));
+        addCookie(headers, cookieParameter.getName(), "", getDefaultStringValue(cookieParameter.getDescription()),
+                "", parameter.getRequired());
     }
 
     private void parseHeaderParameters(Parameter parameter, List<KeyValue> headers) {
         HeaderParameter headerParameter = (HeaderParameter) parameter;
-        addHeader(headers, headerParameter.getName(), "", getDefaultStringValue(headerParameter.getDescription()));
+        addHeader(headers, headerParameter.getName(), "", getDefaultStringValue(headerParameter.getDescription()),
+                "", parameter.getRequired());
     }
 
     private HttpResponse parseResponse(Map<String, Response> responses) {
@@ -311,7 +313,8 @@ public class Swagger2Parser extends ApiImportAbstractParser {
 
     private void parseFormDataParameters(FormParameter parameter, Body body) {
         List<KeyValue> keyValues = Optional.ofNullable(body.getKvs()).orElse(new ArrayList<>());
-        KeyValue kv = new KeyValue(parameter.getName(), "", getDefaultStringValue(parameter.getDescription()));
+        KeyValue kv = new KeyValue(parameter.getName(), "", getDefaultStringValue(parameter.getDescription()),
+                "", parameter.getRequired());
         if (StringUtils.equals(parameter.getType(), "file")) {
             kv.setType("file");
         }
@@ -321,6 +324,7 @@ public class Swagger2Parser extends ApiImportAbstractParser {
 
     private void parseQueryParameters(Parameter parameter, List<KeyValue> arguments) {
         QueryParameter queryParameter = (QueryParameter) parameter;
-        arguments.add(new KeyValue(queryParameter.getName(), "", getDefaultStringValue(queryParameter.getDescription())));
+        arguments.add(new KeyValue(queryParameter.getName(), "", getDefaultStringValue(queryParameter.getDescription()),
+                "", queryParameter.getRequired()));
     }
 }


### PR DESCRIPTION
1、KeyValue中的required属性不能写死，需要在对象构造的时候初始化；
2、HeaderParameter和CookieParameter类型参数，增加required属性；
3、FormParameter、QueryParameter、HeaderParameter和CookieParameter均增加required属性动态传递给KeyValue