### PR TITLE
feat:页面右上角header增加下拉选项‘API文档’

### DIFF
--- a/frontend/src/business/components/common/head/HeaderUser.vue
+++ b/frontend/src/business/components/common/head/HeaderUser.vue
@@ -8,6 +8,7 @@
         <el-dropdown-item command="personal">{{ $t('commons.personal_information') }}</el-dropdown-item>
         <el-dropdown-item command="about">{{ $t('commons.about_us') }} <i class="el-icon-info"/></el-dropdown-item>
         <el-dropdown-item command="help">{{ $t('commons.help_documentation') }}</el-dropdown-item>
+        <el-dropdown-item command="ApiHelp">{{ $t('commons.api_help_documentation') }}</el-dropdown-item>
         <el-dropdown-item command="old" v-show=isReadOnly @click.native="changeBar('old')">
           {{ $t('commons.cut_back_old_version') }}
         </el-dropdown-item>
@@ -63,6 +64,9 @@ export default {
           break;
         case "help":
           window.location.href = "https://metersphere.io/docs/index.html";
+          break;
+        case "ApiHelp":
+          window.open('/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config', "_blank");
           break;
         default:
           break;

--- a/frontend/src/i18n/zh-CN.js
+++ b/frontend/src/i18n/zh-CN.js
@@ -8,6 +8,7 @@ export default {
     comment: '评论',
     examples: '示例',
     help_documentation: '帮助文档',
+    api_help_documentation: 'API文档',
     delete_cancelled: '已取消删除',
     workspace: '工作空间',
     organization: '组织',

--- a/frontend/src/i18n/zh-TW.js
+++ b/frontend/src/i18n/zh-TW.js
@@ -8,6 +8,7 @@ export default {
     comment: '評論',
     examples: '示例',
     help_documentation: '幫助文檔',
+    api_help_documentation: 'API文檔',
     delete_cancelled: '已取消刪除',
     workspace: '工作空間',
     organization: '組織',


### PR DESCRIPTION
在页面右上角header增加下拉选项‘API文档’，点击后浏览器打开新标签，并跳转