### PR TITLE
fix(接口定义): 解决：第一次 swagger 导入后移动 module 位置，再次导入后 module 位置被还原 bug

### DIFF
--- a/backend/src/main/java/io/metersphere/api/service/ApiDefinitionService.java
+++ b/backend/src/main/java/io/metersphere/api/service/ApiDefinitionService.java
@@ -373,6 +373,8 @@ public class ApiDefinitionService {
                 //如果存在则修改
                 apiDefinition.setId(sameRequest.get(0).getId());
                 String request = setImportHashTree(apiDefinition);
+                apiDefinition.setModuleId(sameRequest.get(0).getModuleId());
+                apiDefinition.setModulePath(sameRequest.get(0).getModulePath());
                 apiDefinitionMapper.updateByPrimaryKeyWithBLOBs(apiDefinition);
                 apiDefinition.setRequest(request);
                 importApiCase(apiDefinition, apiTestCaseMapper, apiTestImportRequest, false);


### PR DESCRIPTION
解决：第一次 swagger 导入后移动 module 位置，再次导入后 module 位置被还原 bug