### PR TITLE
fix:空指针异常

### DIFF
--- a/backend/src/main/java/io/metersphere/api/dto/definition/request/dns/MsDNSCacheManager.java
+++ b/backend/src/main/java/io/metersphere/api/dto/definition/request/dns/MsDNSCacheManager.java
@@ -42,7 +42,7 @@ public class MsDNSCacheManager extends MsTestElement {
     }
 
     public static void addEnvironmentDNS(HashTree samplerHashTree, String name, EnvironmentConfig config, HttpConfig httpConfig) {
-        if (config.getCommonConfig().isEnableHost() && CollectionUtils.isNotEmpty(config.getCommonConfig().getHosts()) && httpConfig != null) {
+        if (config.getCommonConfig().isEnableHost() && CollectionUtils.isNotEmpty(config.getCommonConfig().getHosts()) && httpConfig != null && httpConfig.getDomain()!=null) {
             String domain = httpConfig.getDomain().trim();
             List<Host> hosts = new ArrayList<>();
             config.getCommonConfig().getHosts().forEach(host -> {


### PR DESCRIPTION
环境配置开启域名，HTTP 设置 多模块，没有一个 选择 ”无“ 的 HTTP 地址，报空指针异常