### PR TITLE
【测试跟踪，测试计划】进入测试计划执行页面以及按类型进行高级搜索时，报错

### DIFF
--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtTestPlanTestCaseMapper.xml
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtTestPlanTestCaseMapper.xml
@@ -75,7 +75,6 @@
             <include refid="condition">
                 <property name="object" value="${condition}.type"/>
             </include>
-            test_case_review_users
         </if>
         <if test="${condition}.updateTime != null">
             and test_case.update_time


### PR DESCRIPTION
修改  测试跟踪 ->  测试计划-> 进入 测试计划执行页面，按类型搜索报错

我是基于  1.9测的（里面有很多BUG，master分支也有，但是有些已经修复了，改天有时间整理一下），但是我看master分支也有这个错误代码。

希望，该产品越做越好







测试步骤：
1、在测试计划首页，选择一个测试计划点击进入
2、按执行计划页面，点击高级搜索，按类型查询
预期结果：
1、正常进入执行计划页面
2、正常查询
实际结果：
1、进入测试三计划执行页面，提示“网络连接异常，请重试”
2、按类型进行高级搜索后，提示“网络连接异常，请重试”


