### PR TITLE
fix: 测试计划后邮件、微信通知始终为成功 #5829

### DIFF
--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtTestPlanApiCaseMapper.xml
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtTestPlanApiCaseMapper.xml
@@ -68,7 +68,7 @@
       <if test="request.projectId != null and request.projectId!=''">
         and a.projectId = #{request.projectId}
       </if>
-      and t.id in
+      and t.api_case_id in
       <foreach collection="request.ids" item="caseId" separator="," open="(" close=")">
         #{caseId}
       </foreach>

--- a/backend/src/main/java/io/metersphere/track/service/TestPlanReportService.java
+++ b/backend/src/main/java/io/metersphere/track/service/TestPlanReportService.java
@@ -394,14 +394,14 @@ public class TestPlanReportService {
                         countMap.put("Pass", 1);
                     }
                 } else if (StringUtils.equalsAnyIgnoreCase(caseResult, TestPlanApiExecuteStatus.FAILD.name())) {
-                    faliureApiCaseIdList.add(id);
+                    faliureScenarioCaseIdList.add(id);
                     if (countMap.containsKey("Failure")) {
                         countMap.put("Failure", countMap.get("Failure") + 1);
                     } else {
                         countMap.put("Failure", 1);
                     }
                 } else if (StringUtils.equalsAnyIgnoreCase(caseResult, TestPlanApiExecuteStatus.PREPARE.name())) {
-                    faliureApiCaseIdList.add(id);
+                    faliureScenarioCaseIdList.add(id);
                     if (countMap.containsKey("Skip")) {
                         countMap.put("Skip", countMap.get("Skip") + 1);
                     } else {
@@ -437,14 +437,14 @@ public class TestPlanReportService {
                         countMap.put("Pass", 1);
                     }
                 } else if (StringUtils.equalsAnyIgnoreCase(caseResult, TestPlanApiExecuteStatus.FAILD.name())) {
-                    faliureApiCaseIdList.add(id);
+                    faliureLoadCaseIdList.add(id);
                     if (countMap.containsKey("Failure")) {
                         countMap.put("Failure", countMap.get("Failure") + 1);
                     } else {
                         countMap.put("Failure", 1);
                     }
                 } else if (StringUtils.equalsAnyIgnoreCase(caseResult, TestPlanApiExecuteStatus.PREPARE.name())) {
-                    faliureApiCaseIdList.add(id);
+                    faliureLoadCaseIdList.add(id);
                     if (countMap.containsKey("Skip")) {
                         countMap.put("Skip", countMap.get("Skip") + 1);
                     } else {


### PR DESCRIPTION
- 场景、性能失败用例列表名称错误
- 失败api用例查询条件错误