### PR TITLE
Use replaceAll() return value

### DIFF
--- a/backend/src/main/java/io/metersphere/api/dto/definition/request/sampler/MsHTTPSamplerProxy.java
+++ b/backend/src/main/java/io/metersphere/api/dto/definition/request/sampler/MsHTTPSamplerProxy.java
@@ -408,7 +408,7 @@ public class MsHTTPSamplerProxy extends MsTestElement {
                     url = "http://" + url;
                 }
                 if (StringUtils.isNotEmpty(this.getPort()) && this.getPort().startsWith("${")) {
-                    url.replaceAll(this.getPort(), "10990");
+                    url = url.replaceAll(this.getPort(), "10990");
                 }
                 if (url == null) {
                     MSException.throwException("请重新选择环境");


### PR DESCRIPTION
The replaceAll() method returns the result. It does not modify the current string.