### PR TITLE
fix (接口测试): 修复请求头中包含多余参数

### DIFF
--- a/backend/src/main/java/io/metersphere/api/dto/definition/request/sampler/MsHTTPSamplerProxy.java
+++ b/backend/src/main/java/io/metersphere/api/dto/definition/request/sampler/MsHTTPSamplerProxy.java
@@ -237,7 +237,10 @@ public class MsHTTPSamplerProxy extends MsTestElement {
                 sampler.setDoMultipart(true);
             }
             if (CollectionUtils.isNotEmpty(bodyParams)) {
-                sampler.setArguments(httpArguments(bodyParams));
+                Arguments arguments = httpArguments(bodyParams);
+                if (arguments != null && !arguments.getArguments().isEmpty()) {
+                    sampler.setArguments(arguments);
+                }
             }
         }
 

--- a/backend/src/main/java/io/metersphere/api/dto/scenario/Body.java
+++ b/backend/src/main/java/io/metersphere/api/dto/scenario/Body.java
@@ -71,12 +71,14 @@ public class Body {
                 sampler.setDoMultipart(true);
             }
         } else {
-            parseJonBodyMock();
-            KeyValue keyValue = new KeyValue("", "JSON-SCHEMA", this.getRaw(), true, true);
-            sampler.setPostBodyRaw(true);
-            keyValue.setEnable(true);
-            keyValue.setUrlEncode(false);
-            body.add(keyValue);
+            if(StringUtils.isNotEmpty(this.getRaw()) || this.getJsonSchema()!= null ) {
+                parseJonBodyMock();
+                KeyValue keyValue = new KeyValue("", "JSON-SCHEMA", this.getRaw(), true, true);
+                sampler.setPostBodyRaw(true);
+                keyValue.setEnable(true);
+                keyValue.setUrlEncode(false);
+                body.add(keyValue);
+            }
         }
         return body;
     }


### PR DESCRIPTION
--bug=1008180 --user=赵勇 【github #7881】HTTP请求默认添加了"content-type":"text/plain; charset=UTF-8"的请求头 https://www.tapd.cn/55049933/s/1071783