### PR TITLE
fix(系统设置): 全局前/后置脚本配置页面-变更记录-显示变更字段去除

### DIFF
--- a/backend/src/main/java/io/metersphere/log/utils/ReflexObjectUtil.java
+++ b/backend/src/main/java/io/metersphere/log/utils/ReflexObjectUtil.java
@@ -176,7 +176,7 @@ public class ReflexObjectUtil {
                             column.setDiffValue(diffValue);
                         }
                         // 深度对比
-                        else if (StringUtils.equals(module, "api_definition")) {
+                        else if (StringUtils.equals(module, "API_DEFINITION")) {
                             if (originalColumns.get(i).getColumnName().equals("request")) {
                                 String newValue = newColumns.get(i).getOriginalValue().toString();
                                 String oldValue = column.getOriginalValue().toString();

--- a/frontend/src/business/components/history/ChangeHistory.vue
+++ b/frontend/src/business/components/history/ChangeHistory.vue
@@ -9,7 +9,7 @@
         </template>
       </el-table-column>
       <el-table-column prop="userName" :label="$t('operating_log.user')"/>
-      <el-table-column prop="columnTitle" :label="$t('operating_log.change_field')">
+      <el-table-column prop="columnTitle" :label="$t('operating_log.change_field')" v-if="showChangeField">
         <template v-slot:default="scope">
           <div v-if="scope.row.details && scope.row.details.columns">
             <div v-for="detail in scope.row.details.columns" :key="detail.id">{{ detail.columnTitle }}</div>
@@ -71,6 +71,7 @@ export default {
       details: [],
       linkDatas: ["prerequisite", "steps", "remark", "request", "config",
         "response", "scenarioDefinition", "tags", "loadConfiguration", "advancedConfiguration"],
+      showChangeField: true,
     }
   },
   methods: {
@@ -84,6 +85,8 @@ export default {
         if (data) {
           // 过滤非全局脚本历史变更数据
           if(modules.length > 0 && modules[0] === '项目-环境设置'){
+            // 环境设置不显示变更字段
+            this.showChangeField = false;
             // 不显示的节点 id
             let ids = [];
             for(let i=0; i<data.length; i++){
@@ -98,6 +101,8 @@ export default {
                 data.splice(index, 1);
               });
             }
+          }else {
+            this.showChangeField = true;
           }
           this.details = data;
         }


### PR DESCRIPTION
--bug=1010296 --user=周骏弘 全局前/后置脚本配置页面-变更记录-显示变更字段-与需求不符 https://www.tapd.cn/55049933/s/1104974

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.