### PR TITLE
style(接口测试): 场景步骤右侧悬浮按钮样式优化

### DIFF
--- a/frontend/src/business/components/api/automation/scenario/EditApiScenario.vue
+++ b/frontend/src/business/components/api/automation/scenario/EditApiScenario.vue
@@ -600,8 +600,7 @@ export default {
   },
   methods: {
     refreshApiScenario() {
-      this.getApiScenario();
-      this.reloadTree = getUUID();
+      this.getApiScenario(true);
     },
     recursiveSorting(arr) {
       for (let i in arr) {
@@ -1150,6 +1149,9 @@ export default {
       this.$store.state.selectStep = data;
       this.buttonData = buttons(this);
       this.initPlugins();
+      if (this.buttonData.length === 0 && this.$refs.refFab && this.$refs.refFab.active) {
+        this.$refs.refFab.openMenu();
+      }
     },
     suggestClick(node) {
       this.response = {};
@@ -1534,7 +1536,7 @@ export default {
         })
       });
     },
-    getApiScenario() {
+    getApiScenario(isRefresh) {
       this.loading = true;
       this.isBatchProcess = false;
       this.stepEnable = true;
@@ -1618,6 +1620,9 @@ export default {
           this.sort();
           this.$nextTick(() => {
             this.cancelBatchProcessing();
+            if (isRefresh) {
+              this.reloadTree = getUUID();
+            }
           });
           // 记录初始化数据
           let v1 = {


### PR DESCRIPTION
--bug=1011748 --user=赵勇 【接口测试】github#12015，接口自动化中，打开组件栏(即点击"+"图标)，并进行接口请求的页签切换时，组件栏各组件消失，但组件栏仍显示为开启状态 https://www.tapd.cn/55049933/s/1127168

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.