### PR TITLE
style(接口测试): 场景步骤右侧悬浮按钮样式优化

### DIFF
--- a/frontend/src/business/components/api/automation/scenario/EditApiScenario.vue
+++ b/frontend/src/business/components/api/automation/scenario/EditApiScenario.vue
@@ -599,8 +599,7 @@ export default {
   },
   methods: {
     refreshApiScenario() {
-      this.getApiScenario();
-      this.reloadTree = getUUID();
+      this.getApiScenario(true);
     },
     recursiveSorting(arr) {
       for (let i in arr) {
@@ -1154,6 +1153,9 @@ export default {
       this.$store.state.selectStep = data;
       this.buttonData = buttons(this);
       this.initPlugins();
+      if (this.buttonData.length === 0 && this.$refs.refFab && this.$refs.refFab.active) {
+        this.$refs.refFab.openMenu();
+      }
     },
     suggestClick(node) {
       this.response = {};
@@ -1538,7 +1540,7 @@ export default {
         })
       });
     },
-    getApiScenario() {
+    getApiScenario(isRefresh) {
       this.loading = true;
       this.isBatchProcess = false;
       this.stepEnable = true;
@@ -1622,6 +1624,9 @@ export default {
           this.sort();
           this.$nextTick(() => {
             this.cancelBatchProcessing();
+            if (isRefresh) {
+              this.reloadTree = getUUID();
+            }
           });
           // 记录初始化数据
           let v1 = {


### PR DESCRIPTION
--bug=1011748 --user=赵勇 【接口测试】github#12015，接口自动化中，打开组件栏(即点击"+"图标)，并进行接口请求的页签切换时，组件栏各组件消失，但组件栏仍显示为开启状态 https://www.tapd.cn/55049933/s/1127168
