### PR TITLE
fix(接口测试): 缺陷管理-禅道缺陷往ms同步，图片不显示

### DIFF
--- a/backend/src/main/java/io/metersphere/track/issue/ZentaoPlatform.java
+++ b/backend/src/main/java/io/metersphere/track/issue/ZentaoPlatform.java
@@ -39,6 +39,11 @@ import java.util.regex.Pattern;
 public class ZentaoPlatform extends AbstractIssuePlatform {
     protected final ZentaoClient zentaoClient;
 
+    protected final String[] imgArray = {
+        "bmp", "jpg", "png", "tif", "gif", "jpeg"
+    };
+
+
     public ZentaoPlatform(IssuesRequest issuesRequest) {
         super(issuesRequest);
         this.key = IssuesManagePlatform.Zentao.name();
@@ -441,7 +446,11 @@ public class ZentaoPlatform extends AbstractIssuePlatform {
                 if (StringUtils.isEmpty(name)) {
                     name = srcContent;
                 }
-                path = zentaoClient.getBaseUrl() + "/file-read-" + srcContent;
+                if (Arrays.stream(imgArray).anyMatch(imgType -> StringUtils.equals(imgType, srcContent.substring(srcContent.indexOf('.') + 1)))) {
+                    path = zentaoClient.getBaseUrl() + "/file-read-" + srcContent;
+                } else {
+                    return result;
+                }
             }
             // 图片与描述信息之间需换行，否则无法预览图片
             result = "\n\n![" + name + "](" + path + ")";


### PR DESCRIPTION
Milestone v1.19.1
--bug=1011584 --user=zhaoqian
禅道上的描述区域上传图片是不限制文件类型的，但是除了图片其他的都展示不出来，但实际却是已经存到描述里了，ms同步下来会有文件的信息,但是无法预览的情况