### PR TITLE
build: 增加不包含xpack的构建action

### DIFF
--- a/.github/workflows/build-push-oss.yml
+++ b/.github/workflows/build-push-oss.yml
@@ -1,0 +1,88 @@
+name: Build Docker Image and Push without X-Pack Submodules
+
+on:
+  push:
+    branches:
+      - dev
+      - v1*
+      - test-build
+  workflow_dispatch:
+
+jobs:
+  build_push:
+    runs-on: ubuntu-latest
+    name: Build Docker Image and Push without X-Pack Submodules
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: false
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Unzip jar
+        run: mkdir -p backend/target/dependency && (cd backend/target/dependency; jar -xf ../*.jar)
+
+      - name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=metersphere/metersphere
+          DOCKER_PLATFORMS=linux/amd64,linux/arm64
+          TAG_NAME=${{ env.GITHUB_REF_SLUG }}-oss
+          DOCKER_IMAGE_TAGS="--tag ${DOCKER_IMAGE}:${TAG_NAME} --tag ${DOCKER_IMAGE}:latest-oss"
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${TAG_NAME}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
+            --build-arg VERSION=${TAG_NAME} \
+            --build-arg MS_VERSION=${{ env.GITHUB_REF_SLUG }}-${{ env.GITHUB_SHA_SHORT }} \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg VCS_REF=${GITHUB_SHA::8} \
+            ${DOCKER_IMAGE_TAGS} .
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Docker Buildx (build)
+        run: |
+          docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          username: metersphere
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Docker Buildx (push)
+        run: |
+          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+          


### PR DESCRIPTION
#### What this PR does / why we need it?

添加不包含 xpack submodules 的构建 action，避免开源代码中错误地使用了 xpack 相关代码而导致构建失败
