### PR TITLE
fix(环境依赖): 添加package.json中vue-demi配置

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "vue": "2.6.14",
     "vue-calendar-heatmap": "^0.8.4",
     "vue-clipboard2": "^0.3.1",
+    "vue-demi": "^0.12.5",
     "vue-echarts": "^6.0.0",
     "vue-float-action-button": "^0.6.6",
     "vue-i18n": "^8.15.3",


### PR DESCRIPTION
vue-echarts要依赖vue-demi，的package.json没有指定vue-demi的版本，导致本地默认加载了0.11.X的版本，版本过低导致本地启动异常