### PR TITLE
feat(接口测试): 重新设计接口测试首页场景面板覆盖率的统计方法

### DIFF
--- a/backend/src/main/java/io/metersphere/api/controller/APITestController.java
+++ b/backend/src/main/java/io/metersphere/api/controller/APITestController.java
@@ -28,10 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.Resource;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import static io.metersphere.commons.utils.JsonPathUtils.getListJson;
 
@@ -294,10 +291,10 @@ public class APITestController {
          * 接口覆盖率
          * 复制的接口定义/复制或引用的单接口用例/ 添加的自定义请求 url 路径与现有的接口定义一致的请求
          */
-        List<String> allScenarioIdList = apiAutomationService.selectIdsByProjectId(projectId);
+        Map<String,List<String>> scenarioUrlList = apiAutomationService.selectScenarioUseUrlByProjectId(projectId);
         List<ApiDefinition> allEffectiveApiIdList = apiDefinitionService.selectEffectiveIdByProjectId(projectId);
         try {
-            float intetfaceCoverageRageNumber = apiAutomationService.countInterfaceCoverage(allScenarioIdList, allEffectiveApiIdList);
+            float intetfaceCoverageRageNumber = apiAutomationService.countInterfaceCoverage(scenarioUrlList, allEffectiveApiIdList);
             DecimalFormat df = new DecimalFormat("0.0");
             returnStr = df.format(intetfaceCoverageRageNumber) + "%";
         }catch (Exception e){

--- a/backend/src/main/java/io/metersphere/api/mock/utils/MockApiUtils.java
+++ b/backend/src/main/java/io/metersphere/api/mock/utils/MockApiUtils.java
@@ -772,4 +772,48 @@ public class MockApiUtils {
             return false;
         }
     }
+
+    public static boolean isUrlInList(String url,List<String> urlList){
+        if(CollectionUtils.isEmpty(urlList)){
+            return false;
+        }
+        String urlSuffix = url;
+        if(urlSuffix.startsWith("/")){
+            urlSuffix = urlSuffix.substring(1);
+        }
+        String[] urlParams = urlSuffix.split("/");
+        for (String path : urlList) {
+            if (StringUtils.equalsAny(path, url, "/" + url)) {
+                return true;
+            } else {
+                if (StringUtils.isEmpty(path)) {
+                    continue;
+                }
+                if (path.startsWith("/")) {
+                    path = path.substring(1);
+                }
+                if (StringUtils.isNotEmpty(path)) {
+                    String[] pathArr = path.split("/");
+                    if (pathArr.length == urlParams.length) {
+                        boolean isFetch = true;
+                        for (int i = 0; i < urlParams.length; i++) {
+                            String pathItem = pathArr[i];
+                            String urlItem = urlParams[i];
+                            if (!(pathItem.startsWith("{") && pathItem.endsWith("}")) && !(urlItem.startsWith("{") && urlItem.endsWith("}"))) {
+                                if (!StringUtils.equals(pathArr[i], urlParams[i])) {
+                                    isFetch = false;
+                                    break;
+                                }
+                            }
+
+                        }
+                        if (isFetch) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/backend/src/main/java/io/metersphere/api/service/ApiDefinitionService.java
+++ b/backend/src/main/java/io/metersphere/api/service/ApiDefinitionService.java
@@ -1705,14 +1705,12 @@ public class ApiDefinitionService {
     }
 
     public List<ApiDefinitionWithBLOBs> preparedUrl(String projectId, String method, String baseUrlSuffix) {
-
         if (StringUtils.isEmpty(baseUrlSuffix)) {
             return new ArrayList<>();
         } else {
             ApiDefinitionExample example = new ApiDefinitionExample();
             example.createCriteria().andMethodEqualTo(method).andProjectIdEqualTo(projectId).andStatusNotEqualTo("Trash").andProtocolEqualTo("HTTP");
             List<ApiDefinition> apiList = apiDefinitionMapper.selectByExample(example);
-
             List<String> apiIdList = new ArrayList<>();
             boolean urlSuffixEndEmpty = false;
             String urlSuffix = baseUrlSuffix;

--- a/backend/src/main/java/io/metersphere/base/domain/ApiScenarioReferenceId.java
+++ b/backend/src/main/java/io/metersphere/base/domain/ApiScenarioReferenceId.java
@@ -19,5 +19,9 @@ public class ApiScenarioReferenceId implements Serializable {
 
     private String dataType;
 
+    private String url;
+
+    private String method;
+
     private static final long serialVersionUID = 1L;
 }

--- a/backend/src/main/java/io/metersphere/base/domain/ApiScenarioReferenceIdExample.java
+++ b/backend/src/main/java/io/metersphere/base/domain/ApiScenarioReferenceIdExample.java
@@ -583,6 +583,146 @@ public class ApiScenarioReferenceIdExample {
             addCriterion("data_type not between", value1, value2, "dataType");
             return (Criteria) this;
         }
+
+        public Criteria andUrlIsNull() {
+            addCriterion("url is null");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlIsNotNull() {
+            addCriterion("url is not null");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlEqualTo(String value) {
+            addCriterion("url =", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlNotEqualTo(String value) {
+            addCriterion("url <>", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlGreaterThan(String value) {
+            addCriterion("url >", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlGreaterThanOrEqualTo(String value) {
+            addCriterion("url >=", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlLessThan(String value) {
+            addCriterion("url <", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlLessThanOrEqualTo(String value) {
+            addCriterion("url <=", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlLike(String value) {
+            addCriterion("url like", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlNotLike(String value) {
+            addCriterion("url not like", value, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlIn(List<String> values) {
+            addCriterion("url in", values, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlNotIn(List<String> values) {
+            addCriterion("url not in", values, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlBetween(String value1, String value2) {
+            addCriterion("url between", value1, value2, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andUrlNotBetween(String value1, String value2) {
+            addCriterion("url not between", value1, value2, "url");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodIsNull() {
+            addCriterion("`method` is null");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodIsNotNull() {
+            addCriterion("`method` is not null");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodEqualTo(String value) {
+            addCriterion("`method` =", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodNotEqualTo(String value) {
+            addCriterion("`method` <>", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodGreaterThan(String value) {
+            addCriterion("`method` >", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodGreaterThanOrEqualTo(String value) {
+            addCriterion("`method` >=", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodLessThan(String value) {
+            addCriterion("`method` <", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodLessThanOrEqualTo(String value) {
+            addCriterion("`method` <=", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodLike(String value) {
+            addCriterion("`method` like", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodNotLike(String value) {
+            addCriterion("`method` not like", value, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodIn(List<String> values) {
+            addCriterion("`method` in", values, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodNotIn(List<String> values) {
+            addCriterion("`method` not in", values, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodBetween(String value1, String value2) {
+            addCriterion("`method` between", value1, value2, "method");
+            return (Criteria) this;
+        }
+
+        public Criteria andMethodNotBetween(String value1, String value2) {
+            addCriterion("`method` not between", value1, value2, "method");
+            return (Criteria) this;
+        }
     }
 
     public static class Criteria extends GeneratedCriteria {

--- a/backend/src/main/java/io/metersphere/base/mapper/ApiScenarioReferenceIdMapper.xml
+++ b/backend/src/main/java/io/metersphere/base/mapper/ApiScenarioReferenceIdMapper.xml
@@ -9,6 +9,8 @@
     <result column="reference_id" jdbcType="VARCHAR" property="referenceId" />
     <result column="reference_type" jdbcType="VARCHAR" property="referenceType" />
     <result column="data_type" jdbcType="VARCHAR" property="dataType" />
+    <result column="url" jdbcType="VARCHAR" property="url" />
+    <result column="method" jdbcType="VARCHAR" property="method" />
   </resultMap>
   <sql id="Example_Where_Clause">
     <where>
@@ -69,7 +71,8 @@
     </where>
   </sql>
   <sql id="Base_Column_List">
-    id, api_scenario_id, create_time, create_user_id, reference_id, reference_type, data_type
+    id, api_scenario_id, create_time, create_user_id, reference_id, reference_type, data_type, 
+    url, `method`
   </sql>
   <select id="selectByExample" parameterType="io.metersphere.base.domain.ApiScenarioReferenceIdExample" resultMap="BaseResultMap">
     select
@@ -104,10 +107,12 @@
   <insert id="insert" parameterType="io.metersphere.base.domain.ApiScenarioReferenceId">
     insert into api_scenario_reference_id (id, api_scenario_id, create_time, 
       create_user_id, reference_id, reference_type, 
-      data_type)
+      data_type, url, `method`
+      )
     values (#{id,jdbcType=VARCHAR}, #{apiScenarioId,jdbcType=VARCHAR}, #{createTime,jdbcType=BIGINT}, 
       #{createUserId,jdbcType=VARCHAR}, #{referenceId,jdbcType=VARCHAR}, #{referenceType,jdbcType=VARCHAR}, 
-      #{dataType,jdbcType=VARCHAR})
+      #{dataType,jdbcType=VARCHAR}, #{url,jdbcType=VARCHAR}, #{method,jdbcType=VARCHAR}
+      )
   </insert>
   <insert id="insertSelective" parameterType="io.metersphere.base.domain.ApiScenarioReferenceId">
     insert into api_scenario_reference_id
@@ -133,6 +138,12 @@
       <if test="dataType != null">
         data_type,
       </if>
+      <if test="url != null">
+        url,
+      </if>
+      <if test="method != null">
+        `method`,
+      </if>
     </trim>
     <trim prefix="values (" suffix=")" suffixOverrides=",">
       <if test="id != null">
@@ -155,6 +166,12 @@
       </if>
       <if test="dataType != null">
         #{dataType,jdbcType=VARCHAR},
+      </if>
+      <if test="url != null">
+        #{url,jdbcType=VARCHAR},
+      </if>
+      <if test="method != null">
+        #{method,jdbcType=VARCHAR},
       </if>
     </trim>
   </insert>
@@ -188,6 +205,12 @@
       <if test="record.dataType != null">
         data_type = #{record.dataType,jdbcType=VARCHAR},
       </if>
+      <if test="record.url != null">
+        url = #{record.url,jdbcType=VARCHAR},
+      </if>
+      <if test="record.method != null">
+        `method` = #{record.method,jdbcType=VARCHAR},
+      </if>
     </set>
     <if test="_parameter != null">
       <include refid="Update_By_Example_Where_Clause" />
@@ -201,7 +224,9 @@
       create_user_id = #{record.createUserId,jdbcType=VARCHAR},
       reference_id = #{record.referenceId,jdbcType=VARCHAR},
       reference_type = #{record.referenceType,jdbcType=VARCHAR},
-      data_type = #{record.dataType,jdbcType=VARCHAR}
+      data_type = #{record.dataType,jdbcType=VARCHAR},
+      url = #{record.url,jdbcType=VARCHAR},
+      `method` = #{record.method,jdbcType=VARCHAR}
     <if test="_parameter != null">
       <include refid="Update_By_Example_Where_Clause" />
     </if>
@@ -227,6 +252,12 @@
       <if test="dataType != null">
         data_type = #{dataType,jdbcType=VARCHAR},
       </if>
+      <if test="url != null">
+        url = #{url,jdbcType=VARCHAR},
+      </if>
+      <if test="method != null">
+        `method` = #{method,jdbcType=VARCHAR},
+      </if>
     </set>
     where id = #{id,jdbcType=VARCHAR}
   </update>
@@ -237,7 +268,9 @@
       create_user_id = #{createUserId,jdbcType=VARCHAR},
       reference_id = #{referenceId,jdbcType=VARCHAR},
       reference_type = #{referenceType,jdbcType=VARCHAR},
-      data_type = #{dataType,jdbcType=VARCHAR}
+      data_type = #{dataType,jdbcType=VARCHAR},
+      url = #{url,jdbcType=VARCHAR},
+      `method` = #{method,jdbcType=VARCHAR}
     where id = #{id,jdbcType=VARCHAR}
   </update>
 </mapper>

--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioMapper.java
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioMapper.java
@@ -88,4 +88,6 @@ public interface ExtApiScenarioMapper {
     void addLatestVersion(String refId);
 
     List<String> selectRefIdsForVersionChange(@Param("versionId") String versionId, @Param("projectId") String projectId);
+
+    List<ApiScenarioWithBLOBs> selectByStatusIsNotTrash();
 }

--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioMapper.xml
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioMapper.xml
@@ -713,4 +713,7 @@
         </foreach>
         )
     </select>
+    <select id="selectByStatusIsNotTrash" resultType="io.metersphere.base.domain.ApiScenarioWithBLOBs">
+        SELECT * FROM api_scenario WHERE `status` != 'Trash' AND project_id IN (SELECT id FROM project);
+    </select>
 </mapper>

--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioReferenceIdMapper.java
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioReferenceIdMapper.java
@@ -1,9 +1,10 @@
 package io.metersphere.base.mapper.ext;
 
+import io.metersphere.base.domain.ApiScenarioReferenceId;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 public interface ExtApiScenarioReferenceIdMapper {
-    List<String> selectRefIdsFromScenarioIds(@Param("ids") List<String> scenarioIds);
+    List<ApiScenarioReferenceId> selectUrlByProjectId(String projectId);
 }

--- a/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioReferenceIdMapper.xml
+++ b/backend/src/main/java/io/metersphere/base/mapper/ext/ExtApiScenarioReferenceIdMapper.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.metersphere.base.mapper.ext.ExtApiScenarioReferenceIdMapper">
-    <select id="selectRefIdsFromScenarioIds" resultType="java.lang.String">
-        select reference_id from api_scenario_reference_id
-        where api_scenario_id IN
-        <foreach collection="ids" item="v" separator="," open="(" close=")">
-            #{v}
-        </foreach>
+    <select id="selectUrlByProjectId" resultType="io.metersphere.base.domain.ApiScenarioReferenceId">
+        SELECT method,url from api_scenario_reference_id WHERE api_scenario_id in (
+            SELECT id from api_scenario WHERE project_id = #{0}
+        ) AND url IS NOT NULL AND method IS NOT NULL;
     </select>
+
 </mapper>

--- a/backend/src/main/java/io/metersphere/listener/AppStartListener.java
+++ b/backend/src/main/java/io/metersphere/listener/AppStartListener.java
@@ -137,7 +137,7 @@ public class AppStartListener implements ApplicationListener<ApplicationReadyEve
     }
 
     private void initOnceOperate() {
-        initOnceOperate(apiAutomationService::checkApiScenarioReferenceId, "init.scenario.referenceId");
+        initOnceOperate(apiAutomationService::resetApiScenarioReferenceId, "init.scenario.referenceId.reset");
         initOnceOperate(apiAutomationService::initExecuteTimes, "init.scenario.executeTimes");
         initOnceOperate(issuesService::syncThirdPartyIssues, "init.issue");
         initOnceOperate(issuesService::issuesCount, "init.issueCount");

--- a/backend/src/main/resources/db/migration/V115__1.20__release.sql
+++ b/backend/src/main/resources/db/migration/V115__1.20__release.sql
@@ -307,3 +307,10 @@ CREATE PROCEDURE schema_change_rela_two() BEGIN
 END//
 DELIMITER ;
 CALL schema_change_rela_two();
+
+-- 场景步骤引用表增加URL字段，记录引用的api/case/自定义请求中的地址，用于计算覆盖率
+ALTER TABLE api_scenario_reference_id ADD url VARCHAR(500) NULL;
+ALTER TABLE api_scenario_reference_id ADD method VARCHAR(20);
+ALTER TABLE `api_scenario_reference_id` ADD INDEX index_url ( `url`);
+ALTER TABLE `api_scenario_reference_id` ADD INDEX index_method ( `method` );
+ALTER TABLE `api_scenario` ADD INDEX index_project_id ( `project_id`);

--- a/frontend/src/business/components/track/plan/components/TestPlanList.vue
+++ b/frontend/src/business/components/track/plan/components/TestPlanList.vue
@@ -185,14 +185,6 @@
           </template>
         </ms-table-column>
         <ms-table-column
-          prop="executionTimes"
-          :field="item"
-          :fields-width="fieldsWidth"
-          sortable
-          :label="$t('commons.execution_times')"
-          min-width="160px">
-        </ms-table-column>
-        <ms-table-column
           prop="testPlanTestCaseCount"
           :field="item"
           :fields-width="fieldsWidth"


### PR DESCRIPTION
--bug=1012386 --user=宋天阳
[接口测试]github#12735场景的接口覆盖率不能按照api_scenario_reference_id 的api 的id 统计
https://www.tapd.cn/55049933/s/1143296

Closes #12735

[skip ci]

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.