### PR TITLE
build: 使用不同的action处理push及pr

### DIFF
--- a/.github/workflows/add-labels-for-pr.yml
+++ b/.github/workflows/add-labels-for-pr.yml
@@ -1,16 +1,16 @@
-on: [push, pull_request, release]
+on: pull_request
 
-name: MeterSphere pull request handler
+name: MeterSphere 通用 PR 处理
 
 jobs:
   generic_handler:
-    name: Generic handler for MeterSphere Repos
+    name: 为 PR 添加标签
     runs-on: ubuntu-latest
     steps:
       - name: Add labels
         uses: jumpserver/action-generic-handler@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
         with:

--- a/.github/workflows/create-pr-from-push.yml
+++ b/.github/workflows/create-pr-from-push.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:    
+      - 'pr@**'
+      - 'repr@**'
+
+name: 针对特定分支名自动创建 PR
+
+jobs:
+  generic_handler:
+    name: 自动创建 PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: jumpserver/action-generic-handler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: ${{ github.base_ref }}


### PR DESCRIPTION
#### What this PR does / why we need it?

将原本的自动创建 pr、给 pr 打标签的 action 拆分为两个，减少触发不必要的 action

#### Summary of your change

将原本的 auto-pr action 拆分成了两个，一个处理 pr@** 和 repr@** 分支名的 push 事件，一个处理 pull_request 事件
