### PR TITLE
修复了数据库配置中账号密码明文传输，更新或修改配置环境时，前后端对于“链接超时”等信息进行校验，再进行数据库配置时同样进行前后端校验。

### DIFF
--- a/frontend/src/business/components/project/menu/EnvironmentList.vue
+++ b/frontend/src/business/components/project/menu/EnvironmentList.vue
@@ -255,7 +255,13 @@ export default {
       }
       let url = '/api/environment/list/' + this.currentPage + '/' + this.pageSize;
       this.result = this.$post(url, this.condition, response => {
-        this.environments = response.data.listObject;
+        // this.environments = response.data.listObject;
+        let Base64 = require('js-base64').Base64
+        let tmp = response.data.listObject;
+        for (let i = 0; i < tmp.length; ++i){
+          tmp[i].config = Base64.decode(tmp[i].config);
+        }
+        this.environments = tmp;
         this.total = response.data.itemCount;
       })
     },

--- a/frontend/src/business/components/settings/workspace/environment/EnvironmentList.vue
+++ b/frontend/src/business/components/settings/workspace/environment/EnvironmentList.vue
@@ -299,7 +299,13 @@ export default {
       }
       let url = '/api/environment/list/' + this.currentPage + '/' + this.pageSize;
       this.result = this.$post(url, this.condition, response => {
-        this.environments = response.data.listObject;
+        // this.environments = response.data.listObject;
+        let Base64 = require('js-base64').Base64
+        let tmp = response.data.listObject;
+        for (let i = 0; i < tmp.length; ++i){
+          tmp[i].config = Base64.decode(tmp[i].config);
+        }
+        this.environments = tmp;
         this.total = response.data.itemCount;
       });
     },


### PR DESCRIPTION
#### What this PR does / why we need it?
修复在数据库配置中，发现数据库账号密码明文返回给前端[issue 7680](https://github.com/metersphere/metersphere/issues/7680)
修复更新或修改配置环境时“链接超时”前后端都没有进行校验[issue 14112](https://github.com/metersphere/metersphere/issues/14112)
#### Summary of your change
数据库配置信息编码后传输
更新或修改配置环境时，前后端对于“链接超时”等信息进行校验，再进行数据库配置时同样进行前后端校验。
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.