### PR TITLE
Update ElementUtil.java

### DIFF
--- a/backend/src/main/java/io/metersphere/api/dto/definition/request/ElementUtil.java
+++ b/backend/src/main/java/io/metersphere/api/dto/definition/request/ElementUtil.java
@@ -31,6 +31,7 @@ import io.metersphere.plugin.core.MsParameter;
 import io.metersphere.plugin.core.MsTestElement;
 import io.metersphere.service.EnvironmentGroupProjectService;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.CSVDataSet;
@@ -414,7 +415,7 @@ public class ElementUtil {
                 } else if (element != null && element.get("type").toString().equals("HTTPSamplerProxy")) {
                     MsHTTPSamplerProxy httpSamplerProxy = JSON.toJavaObject(element, MsHTTPSamplerProxy.class);
                     if (httpSamplerProxy != null
-                            && (!httpSamplerProxy.isCustomizeReq() || (httpSamplerProxy.isCustomizeReq() && httpSamplerProxy.getIsRefEnvironment()))) {
+                            && (!httpSamplerProxy.isCustomizeReq() || (httpSamplerProxy.isCustomizeReq() && BooleanUtils.isTrue(httpSamplerProxy.getIsRefEnvironment())))) {
                         // 多态JSON普通转换会丢失内容，需要通过 ObjectMapper 获取
                         if (element != null && StringUtils.isNotEmpty(element.getString("hashTree"))) {
                             LinkedList<MsTestElement> elements = mapper.readValue(element.getString("hashTree"),


### PR DESCRIPTION
fixed 设置引用环境，没有带出来环境的url前缀。
重现步骤：
为环境指定http协议，域名，端口
为场景指定环境为上述环境
该场景中有2个自定义请求，第一个自定义请求没有设置引用环境，
第二个自定义请求点引用环境按钮时无法带出环境的url前缀。
原因：处理第一个自定义请求时，抛出空指针异常
修复方法：
io.metersphere.api.dto.definition.request.ElementUtil#dataSetDomain 中判断 getIsRefEnvironment是否为true时先判断是否是null。BooleanUtils.isTrue(httpSamplerProxy.getIsRefEnvironment()))

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.