### PR TITLE
fix(sec): upgrade com.github.pagehelper:pagehelper to 5.3.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 
     <parent>
@@ -122,7 +120,7 @@
         <dependency>
             <groupId>com.github.pagehelper</groupId>
             <artifactId>pagehelper</artifactId>
-            <version>5.3.0</version>
+            <version>5.3.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.github.pagehelper:pagehelper 5.3.0
- [CVE-2022-28111](https://www.oscs1024.com/hd/CVE-2022-28111)


### What did I do？
Upgrade com.github.pagehelper:pagehelper from 5.3.0 to 5.3.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS