### PR TITLE
fix(接口测试)场景定义中的groovy脚本没有开启cacheKey=true，导致压测性能差问题

### DIFF
--- a/api-test/backend/src/main/java/io/metersphere/api/dto/definition/request/ElementUtil.java
+++ b/api-test/backend/src/main/java/io/metersphere/api/dto/definition/request/ElementUtil.java
@@ -847,6 +847,11 @@ public class ElementUtil {
         } else {
             testElement.setProperty("scriptLanguage", vo.getScriptLanguage());
             testElement.setProperty(ElementConstants.SCRIPT, vo.getScript());
+            if ("groovy".equalsIgnoreCase(vo.getScriptLanguage())) {
+                // groovy脚本开启脚本缓存，提高压测性能
+                testElement.setProperty("cacheKey", "true");
+            }
+
         }
     }
 


### PR DESCRIPTION
#### What this PR does / why we need it?
接口测试中场景定义增加自定义groovy脚本，cacheKey没有设置为true，导出jmeter脚本在jmeter中查看脚本编译缓存没有勾选，导致压测是性能损耗很大

#### Summary of your change
生成JSR223脚本节点的cacheKey时判断是groovy脚本，则设置为true

