### PR TITLE
fix(接口测试): 修复接口导入未导入query值的缺陷

### DIFF
--- a/backend/services/api-test/src/main/java/io/metersphere/api/parser/api/Swagger3Parser.java
+++ b/backend/services/api-test/src/main/java/io/metersphere/api/parser/api/Swagger3Parser.java
@@ -434,6 +434,9 @@ public class Swagger3Parser<T> implements ImportParser<ApiDefinitionImport> {
             queryParam.setMinLength(queryParameter.getSchema().getMinLength());
             queryParam.setMaxLength(queryParameter.getSchema().getMaxLength());
         }
+        if (queryParameter.getExample() != null) {
+            queryParam.setValue(getDefaultObjectValue(queryParameter.getExample()));
+        }
         arguments.add(queryParam);
     }
 
@@ -445,6 +448,9 @@ public class Swagger3Parser<T> implements ImportParser<ApiDefinitionImport> {
         if (cookieParameter.getSchema() != null) {
             headerParams.setValue(getDefaultObjectValue(cookieParameter.getSchema().getExample()));
         }
+        if (cookieParameter.getExample() != null) {
+            headerParams.setValue(getDefaultObjectValue(cookieParameter.getExample()));
+        }
         headers.add(headerParams);
     }
 
@@ -454,6 +460,9 @@ public class Swagger3Parser<T> implements ImportParser<ApiDefinitionImport> {
         headerParams.setDescription(getDefaultStringValue(headerParameter.getDescription()));
         if (headerParameter.getSchema() != null) {
             headerParams.setValue(getDefaultObjectValue(headerParameter.getSchema().getExample()));
+        }
+        if (headerParameter.getExample() != null) {
+            headerParams.setValue(getDefaultObjectValue(headerParameter.getExample()));
         }
         headers.add(headerParams);
     }
@@ -469,6 +478,9 @@ public class Swagger3Parser<T> implements ImportParser<ApiDefinitionImport> {
             restParam.setValue(getDefaultObjectValue(parameter.getSchema().getExample()));
             restParam.setMinLength(parameter.getSchema().getMinLength());
             restParam.setMaxLength(parameter.getSchema().getMaxLength());
+        }
+        if (parameter.getExample() != null) {
+            restParam.setValue(getDefaultObjectValue(parameter.getExample()));
         }
         rest.add(restParam);
     }


### PR DESCRIPTION
--bug=1039645 --user=王孝刚 【接口测试】接口定义-导入swagger文件中query参数值未导入 https://www.tapd.cn/55049933/s/1500400

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.