### PR TITLE
fix(接口测试):场景编辑页面编辑器折叠展开导致页面卡死问题

### DIFF
--- a/api-test/frontend/src/business/automation/scenario/component/Jsr233Processor.vue
+++ b/api-test/frontend/src/business/automation/scenario/component/Jsr233Processor.vue
@@ -14,7 +14,7 @@
     :title="title"
     v-loading="loading">
     <!--自定义脚本-->
-    <legend style="width: 100%; display: table-column" v-if="request && this.request.type === 'JSR223Processor'">
+    <legend style="width: 100%; display: table-column" v-if="request && this.request.type === 'JSR223Processor' && jsr223Processor.active">
       <p class="ms-tip">{{ $t('api_test.definition.request.req_param') }}</p>
       <el-tabs v-model="activeName" class="request-tabs" @tab-click="tabClick">
         <!-- 请求头-->


### PR DESCRIPTION
### MeterSphere 版本
v2.10.15-lts
### 问题描述
类型：性能问题
版本：v2.10以及以前
页面：【接口测试】场景编辑页
![image](https://github.com/metersphere/metersphere/assets/39110024/24e148a1-f6da-4e07-86ee-60c8f8901b6b)
现象：浏览器卡死
![image](https://github.com/metersphere/metersphere/assets/39110024/d6a1f7b9-4def-4fa3-86f7-0fc0dfc70e48)
### 重现步骤
1. 创建20条以上的场景步骤数据，包含场景编辑器（**自定义脚本**）
2. 大量展开场景步骤，让滚动条长度逐渐变小，展开编辑器后滚动条最终滚到底部
3. 将滚动条快速从底部快速拖动到顶部，多次点击展开、折叠**自定义脚本编辑器**
4. 浏览器卡死。

_说明：上述步骤是必现的方式。另外也有偶现的情况，展开很多编辑器后，加上虚拟滚动的原因，不停的展开或折叠**自定义脚本编**辑器也会卡死。_

### 关联issue
_说明：虽然issue都被关闭，但问题实际没有解决。_
https://github.com/metersphere/metersphere/pull/25577