### PR TITLE
fix this is incompatible with sql_mode=only_full_group_by

### DIFF
--- a/system-setting/backend/src/main/resources/db/migration/V68__modify_api_test_case.sql
+++ b/system-setting/backend/src/main/resources/db/migration/V68__modify_api_test_case.sql
@@ -1,4 +1,5 @@
 SET SESSION innodb_lock_wait_timeout = 7200;
+SET sql_mode ='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
 ALTER TABLE api_test_case drop COLUMN response;
 ALTER TABLE api_test_case add COLUMN last_result_id varchar(64) COMMENT 'Last ApiDefinitionExecResult ID';
 


### PR DESCRIPTION
when mysql version>=5.7.5, When executing V68__modify_api_test_case.sql SQL, this issue arises because, simply put:
Due to the activation of the ONLY_FULL_GROUP_BY setting
![image](https://github.com/user-attachments/assets/7907ff84-0518-4244-9777-51ceeaf97081)
