### PR TITLE
fix: 解决metersphere-system-setting没有生成Classifier为tests的jar

### DIFF
--- a/backend/services/system-setting/pom.xml
+++ b/backend/services/system-setting/pom.xml
@@ -188,7 +188,11 @@
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
+                            <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>tests</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
metersphere-system-setting没有生成Classifier为tests的jar，但是其他模块引入了Classifier为tests的jar，导致编译无法通过

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.