### PR TITLE
fix(system-setting encrypt): 移除不必要的 toString() 调用,以防值为 null 时空指针

### DIFF
--- a/backend/services/system-setting/src/main/java/io/metersphere/system/notice/sender/impl/MailNoticeSender.java
+++ b/backend/services/system-setting/src/main/java/io/metersphere/system/notice/sender/impl/MailNoticeSender.java
@@ -56,7 +56,7 @@ public class MailNoticeSender extends AbstractNoticeSender {
         List<SystemParameter> paramList = systemParameterMapper.selectByExample(example);
         Map<String, String> paramMap = paramList.stream().collect(Collectors.toMap(SystemParameter::getParamKey, p -> {
             if (StringUtils.equals(p.getParamKey(), ParamConstants.MAIL.PASSWORD.getValue())) {
-                return EncryptUtils.aesDecrypt(p.getParamValue()).toString();
+                return EncryptUtils.aesDecrypt(p.getParamValue());
             }
             if (StringUtils.isEmpty(p.getParamValue())) {
                 return "";

--- a/backend/services/system-setting/src/main/java/io/metersphere/system/service/SimpleUserService.java
+++ b/backend/services/system-setting/src/main/java/io/metersphere/system/service/SimpleUserService.java
@@ -472,7 +472,7 @@ public class SimpleUserService {
         systemParameters.forEach(systemParameter -> {
             if (systemParameter.getParamKey().equals(ParamConstants.MAIL.PASSWORD.getValue())) {
                 if (!StringUtils.isBlank(systemParameter.getParamValue())) {
-                    String string = EncryptUtils.aesDecrypt(systemParameter.getParamValue()).toString();
+                    String string = EncryptUtils.aesDecrypt(systemParameter.getParamValue());
                     emailMap.put(systemParameter.getParamKey(), string);
                 }
             } else {

--- a/backend/services/system-setting/src/main/java/io/metersphere/system/service/SystemParameterService.java
+++ b/backend/services/system-setting/src/main/java/io/metersphere/system/service/SystemParameterService.java
@@ -132,7 +132,7 @@ public class SystemParameterService {
                 } else if (StringUtils.equals(param.getParamKey(), ParamConstants.MAIL.FROM.getValue())) {
                     mailInfo.setFrom(param.getParamValue());
                 } else if (StringUtils.equals(param.getParamKey(), ParamConstants.MAIL.PASSWORD.getValue())) {
-                    String password = EncryptUtils.aesDecrypt(param.getParamValue()).toString();
+                    String password = EncryptUtils.aesDecrypt(param.getParamValue());
                     mailInfo.setPassword(password);
                 } else if (StringUtils.equals(param.getParamKey(), ParamConstants.MAIL.SSL.getValue())) {
                     mailInfo.setSsl(param.getParamValue());


### PR DESCRIPTION
#### What this PR does / why we need it?

修复在未填写 SMTP 密码时保存邮件设置会导致后端空指针异常的问题，且 aesDecrypt 方法就是返回的 String 无需再次调用 toString。

Related issues
Closes #35129

#### Summary of your change

- 避免对 null 调用 toString() 引发异常。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.