### PR TITLE
ci: cancel duplicate CI runs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,6 +6,11 @@ on:
       - "backend/**"
       - "pom.xml"
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 name: MeterSphere 覆盖率统计
 
 permissions:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - "frontend/**"
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 name: MeterSphere 前端代码校验
 
 permissions:


### PR DESCRIPTION
#### What this PR does / why we need it?
Speed up your CI/CD process by saving unnecessary runs 🌱

#### Summary of your change
Currently, if a PR is open and a push happens, the **MeterSphere 覆盖率统计** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

#### Example
Here is an example of the behaviour described above: the commit `104f540` triggered [this](https://github.com/metersphere/metersphere/actions/runs/11435183710/) workflow run, and shortly after the commit `74dba73`, that happened on top of the first commit, triggered [this](https://github.com/metersphere/metersphere/actions/runs/11435186801/) workflow. Both workflows ran till the end, spending approximately 1.2 CPU hours each. With the proposed changes, the first run would be cancelled, hence saving ~1.2 CPU hours and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **2 CPU days** over the last few months.

The same holds for these workflow(s) as well: MeterSphere 前端代码校验.
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.