### PR TITLE
fix: comment out base-url endpoint in filter chain definition

### DIFF
--- a/backend/framework/sdk/src/main/java/io/metersphere/sdk/util/FilterChainUtils.java
+++ b/backend/framework/sdk/src/main/java/io/metersphere/sdk/util/FilterChainUtils.java
@@ -74,7 +74,7 @@ public class FilterChainUtils {
         filterChainDefinitionMap.put("/api/share/doc/view/**", "anon");
 
         filterChainDefinitionMap.put("/system/theme", "anon");
-        filterChainDefinitionMap.put("/system/parameter/save/base-url/**", "anon");
+       // filterChainDefinitionMap.put("/system/parameter/save/base-url/**", "anon");
         filterChainDefinitionMap.put("/system/timeout", "anon");
         filterChainDefinitionMap.put("/file/metadata/info/**", "anon");
         // consul


### PR DESCRIPTION
fix: comment out base-url endpoint in filter chain definition 